### PR TITLE
[refactor] CommunityMapper의 책임을 다른 서비스로 인가했습니다.

### DIFF
--- a/src/main/java/com/imfine/ngs/community/controller/CommunityBoardController.java
+++ b/src/main/java/com/imfine/ngs/community/controller/CommunityBoardController.java
@@ -10,6 +10,7 @@ import com.imfine.ngs.community.dto.response.CommunityBoardCreateResponse;
 import com.imfine.ngs.community.dto.response.CommunityBoardResponse;
 import com.imfine.ngs.community.entity.CommunityBoard;
 import com.imfine.ngs.community.service.CommunityBoardService;
+import com.imfine.ngs.community.service.CommunityUserService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class CommunityBoardController {
   private final CommunityBoardService boardService;
-  private final CommunityMapper mapper;
+  private final CommunityUserService userService;
 
   /**
    * 게시판을 생성합니다.
@@ -42,8 +43,8 @@ public class CommunityBoardController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody @Valid CommunityBoardCreateRequest boardReq
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
-    CommunityBoard board = mapper.toCommunityBoard(boardReq, user, principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
+    CommunityBoard board = CommunityMapper.toCommunityBoard(boardReq, user);
     try {
       Long boardId = boardService.addBoard(board);
       return ResponseEntity.ok(CommunityBoardCreateResponse.builder()
@@ -61,12 +62,13 @@ public class CommunityBoardController {
           @RequestParam(defaultValue = "0") int page,
           @RequestParam(defaultValue = "20") int size
   ) {
-    CommunityUser user = mapper.getCommunityUserOrAnonymous(principal);
+    CommunityUser user = userService.getCommunityUserOrAnonymous(principal);
     Pageable pageable = PageRequest.of(page, size);
 
     try {
       Page<CommunityBoard> boards = boardService.getAllBoards(user, pageable);
-      Page<CommunityBoardResponse> response = boards.map(mapper::toCommunityBoardResponse);
+      Page<CommunityBoardResponse> response = boards
+              .map(CommunityMapper::toCommunityBoardResponse);
       return ResponseEntity.ok(response);
     }  catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
@@ -87,7 +89,7 @@ public class CommunityBoardController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody @Valid CommunityBoardDescriptionDto descriptionDto
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
 
     try {
       boardService.setDescription(user, boardId, descriptionDto.getDescription());
@@ -111,8 +113,8 @@ public class CommunityBoardController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody @Valid CommunityBoardManagerDto managerDto
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
-    CommunityUser target = mapper.getAuthorOrThrow(managerDto.getManagerId());
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
+    CommunityUser target = userService.getAuthorOrThrow(managerDto.getManagerId());
 
     try {
       boardService.setManager(boardId, user, target);
@@ -134,7 +136,7 @@ public class CommunityBoardController {
           @PathVariable Long boardId,
           @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
 
     try {
       boardService.deleteBoard(user, boardId);

--- a/src/main/java/com/imfine/ngs/community/controller/CommunityCommentController.java
+++ b/src/main/java/com/imfine/ngs/community/controller/CommunityCommentController.java
@@ -7,6 +7,7 @@ import com.imfine.ngs.community.dto.request.CommunityCommentRequest;
 import com.imfine.ngs.community.dto.response.CommunityCommentResponse;
 import com.imfine.ngs.community.entity.CommunityComment;
 import com.imfine.ngs.community.service.CommunityCommentService;
+import com.imfine.ngs.community.service.CommunityUserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,14 +17,16 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 @RestController
 @RequestMapping("/api/community")
 @RequiredArgsConstructor
 public class CommunityCommentController {
-  private final CommunityMapper mapper;
   private final CommunityCommentService commentService;
+  private final CommunityUserService userService;
 
   /**
    * 댓글을 작성합니다.
@@ -38,10 +41,10 @@ public class CommunityCommentController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody @Valid CommunityCommentRequest request
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
     request.setPostId(postId);
     request.setAuthor(user);
-    CommunityComment comment = mapper.toComment(request);
+    CommunityComment comment = CommunityMapper.toComment(request);
 
     try {
       commentService.addComment(user, comment);
@@ -62,12 +65,15 @@ public class CommunityCommentController {
           @PathVariable Long postId,
           @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser user = mapper.getCommunityUserOrAnonymous(principal);
+    CommunityUser user = userService.getCommunityUserOrAnonymous(principal);
 
     List<CommunityComment> comments = commentService.getCommentsByPostId(user, postId);
 
     try {
-      return ResponseEntity.ok(mapper.toCommentResponses(comments));
+      return ResponseEntity.ok(
+              comments.stream()
+                .map(c -> CommunityMapper.toCommentResponse(c, userService.getAuthorOrThrow(c.getAuthorId())))
+                .toList());
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
@@ -89,8 +95,8 @@ public class CommunityCommentController {
   ) {
     try {
       Page<CommunityComment> comments = commentService.getCommentsByAuthorId(userId, page, size);
-      Page<CommunityCommentResponse> responses = mapper.toCommentResponses(comments);
-      return ResponseEntity.ok(responses);
+      return ResponseEntity.ok(comments
+              .map(c -> CommunityMapper.toCommentResponse(c, userService.getAuthorOrThrow(c.getAuthorId()))));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
@@ -109,7 +115,7 @@ public class CommunityCommentController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody String content
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
 
     try {
       commentService.editComment(user, commentId, content);
@@ -130,7 +136,7 @@ public class CommunityCommentController {
           @PathVariable Long commentId,
           @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
 
     try {
       commentService.deleteComment(user, commentId);

--- a/src/main/java/com/imfine/ngs/community/controller/CommunityPostController.java
+++ b/src/main/java/com/imfine/ngs/community/controller/CommunityPostController.java
@@ -10,6 +10,8 @@ import com.imfine.ngs.community.entity.CommunityPost;
 import com.imfine.ngs.community.entity.CommunityTag;
 import com.imfine.ngs.community.enums.SearchType;
 import com.imfine.ngs.community.service.CommunityPostService;
+import com.imfine.ngs.community.service.CommunityTagService;
+import com.imfine.ngs.community.service.CommunityUserService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +30,9 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/community")
 @RequiredArgsConstructor
 public class CommunityPostController {
-  private final CommunityMapper mapper;
   private final CommunityPostService postService;
+  private final CommunityUserService userService;
+  private final CommunityTagService tagService;
 
   /**
    * 게시글을 작성합니다.
@@ -45,8 +48,8 @@ public class CommunityPostController {
           @AuthenticationPrincipal JwtUserPrincipal principal,
           @RequestBody @Valid CommunityPostCreateRequest request
   ) {
-    CommunityUser communityUser = mapper.getCommunityUserOrThrow(principal);
-    List<CommunityTag> tags = mapper.toTagsForMutation(request.getTags());
+    CommunityUser communityUser = userService.getCommunityUserOrThrow(principal);
+    List<CommunityTag> tags = tagService.toTagsForMutation(request.getTags());
 
     CommunityPost newPost = CommunityPost.builder()
             .boardId(boardId)
@@ -59,7 +62,7 @@ public class CommunityPostController {
     try {
       Long createdId = postService.addPost(communityUser, newPost);
       CommunityPost created = postService.getPostById(communityUser, createdId);
-      return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toCommunityPostResponse(created));
+      return ResponseEntity.status(HttpStatus.CREATED).body(CommunityMapper.toCommunityPostResponse(created, communityUser));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
     }
@@ -86,9 +89,9 @@ public class CommunityPostController {
           @RequestParam(value = "page", defaultValue = "0") int page,
           @RequestParam(value = "size", defaultValue = "20") int size
   ) {
-    CommunityUser communityUser = mapper.getCommunityUserOrAnonymous(principal);
+    CommunityUser communityUser = userService.getCommunityUserOrAnonymous(principal);
     Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, "created_at");
-    List<CommunityTag> tags = mapper.toTagsForSearch(tagNames);
+    List<CommunityTag> tags = tagService.toTagsForSearch(tagNames);
 
     CommunityPostSearchForm searchForm = CommunityPostSearchForm.builder()
             .type(searchType != null ? searchType : SearchType.TITLE_ONLY)
@@ -99,7 +102,7 @@ public class CommunityPostController {
 
     try {
       Page<CommunityPost> posts = postService.getPostsWithSearch(communityUser, boardId, searchForm);
-      Page<CommunityPostResponse> response = posts.map(mapper::toCommunityPostResponse);
+      Page<CommunityPostResponse> response = posts.map(p -> CommunityMapper.toCommunityPostResponse(p, userService.getAuthorOrThrow(p.getAuthorId())));
       return ResponseEntity.ok(response);
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
@@ -117,10 +120,10 @@ public class CommunityPostController {
       @PathVariable Long postId,
       @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser communityUser = mapper.getCommunityUserOrAnonymous(principal);
+    CommunityUser communityUser = userService.getCommunityUserOrAnonymous(principal);
     try {
       CommunityPost post = postService.getPostById(communityUser, postId);
-      return ResponseEntity.ok(mapper.toCommunityPostResponse(post));
+      return ResponseEntity.ok(CommunityMapper.toCommunityPostResponse(post, userService.getAuthorOrThrow(post.getAuthorId())));
     } catch (IllegalArgumentException ex) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
     }
@@ -140,8 +143,8 @@ public class CommunityPostController {
       @RequestBody @Valid CommunityPostUpdateRequest request,
       @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser communityUser = mapper.getCommunityUserOrThrow(principal);
-    List<CommunityTag> tags = mapper.toTagsForMutation(request.getTags());
+    CommunityUser communityUser = userService.getCommunityUserOrThrow(principal);
+    List<CommunityTag> tags = tagService.toTagsForMutation(request.getTags());
 
     CommunityPost targetPost = CommunityPost.builder()
         .boardId(request.getBoardId())
@@ -171,7 +174,7 @@ public class CommunityPostController {
       @PathVariable Long postId,
       @AuthenticationPrincipal JwtUserPrincipal principal
   ) {
-    CommunityUser user = mapper.getCommunityUserOrThrow(principal);
+    CommunityUser user = userService.getCommunityUserOrThrow(principal);
     try {
       postService.deletePost(user, postId);
       return ResponseEntity.noContent().build();

--- a/src/main/java/com/imfine/ngs/community/controller/mapper/CommunityMapper.java
+++ b/src/main/java/com/imfine/ngs/community/controller/mapper/CommunityMapper.java
@@ -12,6 +12,7 @@ import com.imfine.ngs.community.entity.CommunityComment;
 import com.imfine.ngs.community.entity.CommunityPost;
 import com.imfine.ngs.community.entity.CommunityTag;
 import com.imfine.ngs.community.service.CommunityTagService;
+import com.imfine.ngs.user.entity.User;
 import com.imfine.ngs.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,29 +24,25 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@Component
 @RequiredArgsConstructor
 public class CommunityMapper {
   private static final String DEFAULT_ROLE = "USER";
 
-  private final CommunityTagService tagService;
-  private final UserRepository userRepository;
-
-  public CommunityBoard toCommunityBoard(
+  public static CommunityBoard toCommunityBoard(
           CommunityBoardCreateRequest request,
-          CommunityUser user,
-          @AuthenticationPrincipal JwtUserPrincipal principal) {
+          CommunityUser user) {
     return CommunityBoard.builder()
             .gameId(request.getGameId())
             .title(request.getTitle())
             .description(request.getDescription())
-            .managerId(user != null ? user.getId() : getCommunityUserOrAnonymous(principal).getId())
+            .managerId(user.getId())
             .build();
   }
 
-  public CommunityBoardResponse toCommunityBoardResponse(CommunityBoard board) {
+  public static CommunityBoardResponse toCommunityBoardResponse(CommunityBoard board) {
     return CommunityBoardResponse.builder()
             .id(board.getId())
             .title(board.getTitle())
@@ -55,70 +52,11 @@ public class CommunityMapper {
             .build();
   }
 
-  public CommunityPostResponse toCommunityPostResponse(CommunityPost post) {
-    CommunityUser author = getAuthorOrThrow(post.getAuthorId());
+  public static CommunityPostResponse toCommunityPostResponse(CommunityPost post, CommunityUser author) {
     return CommunityPostResponse.from(post, author);
   }
 
-  private CommunityUser loadUser(Long userId, HttpStatus status, String message) {
-    return userRepository.findById(userId)
-            .map(CommunityUser::of)
-            .orElseThrow(() -> new ResponseStatusException(status, message));
-  }
-
-  public CommunityUser getAuthorOrThrow(Long authorId) {
-    return loadUser(authorId, HttpStatus.NOT_FOUND, "작성자를 찾을 수 없습니다.");
-  }
-
-  public CommunityUser getCommunityUserOrAnonymous(JwtUserPrincipal principal) {
-    if (principal == null) {
-      return CommunityUser.builder().role(DEFAULT_ROLE).build();
-    }
-
-    return loadUser(principal.getUserId(), HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
-  }
-
-  public CommunityUser getCommunityUserOrThrow(JwtUserPrincipal principal) {
-    if (principal == null) {
-      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
-    }
-    return getCommunityUserOrAnonymous(principal);
-  }
-
-  public List<CommunityTag> toTagsForMutation(List<String> tagNames) {
-    List<String> normalizedNames = normalizeTagNames(tagNames);
-    if (normalizedNames.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return normalizedNames.stream()
-            .map(tagService::getTagByName)
-            .collect(Collectors.toList());
-  }
-
-  public List<CommunityTag> toTagsForSearch(List<String> tagNames) {
-    List<String> normalizedNames = normalizeTagNames(tagNames);
-    if (normalizedNames.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return normalizedNames.stream()
-            .map(name -> CommunityTag.builder().name(name).build())
-            .collect(Collectors.toList());
-  }
-
-  private List<String> normalizeTagNames(List<String> tagNames) {
-    if (tagNames == null || tagNames.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return tagNames.stream()
-            .filter(StringUtils::hasText)
-            .map(String::trim)
-            .collect(Collectors.toList());
-  }
-
-  public CommunityComment toComment(CommunityCommentRequest request) {
+  public static CommunityComment toComment(CommunityCommentRequest request) {
     return CommunityComment.builder()
             .postId(request.getPostId())
             .authorId(request.getAuthor().getId())
@@ -127,25 +65,14 @@ public class CommunityMapper {
             .build();
   }
 
-  // TODO: CommunityComment -> CommunityCommentResponse
-  public CommunityCommentResponse toCommentResponse(CommunityComment comment) {
+  public static CommunityCommentResponse toCommentResponse(CommunityComment comment, CommunityUser author) {
     return CommunityCommentResponse.builder()
             .id(comment.getId())
             .parentId(comment.getParentId())
-            .user(getAuthorOrThrow(comment.getAuthorId()))
+            .user(author)
             .content(comment.getContent())
             .createdAt(comment.getCreatedAt())
             .updatedAt(comment.getUpdatedAt())
             .build();
-  }
-
-  public List<CommunityCommentResponse> toCommentResponses(List<CommunityComment> comments) {
-    return comments.stream()
-            .map(this::toCommentResponse)
-            .collect(Collectors.toList());
-  }
-
-  public Page<CommunityCommentResponse> toCommentResponses(Page<CommunityComment> comments) {
-    return comments.map(this::toCommentResponse);
   }
 }

--- a/src/main/java/com/imfine/ngs/community/service/CommunityTagService.java
+++ b/src/main/java/com/imfine/ngs/community/service/CommunityTagService.java
@@ -5,8 +5,11 @@ import com.imfine.ngs.community.repository.CommunityTagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +34,39 @@ public class CommunityTagService {
 
   public List<CommunityTag> getTagsByName(String tmpText) {
     return tagRepository.findAllByName(tmpText);
+  }
+
+
+  private List<String> normalizeTagNames(List<String> tagNames) {
+    if (tagNames == null || tagNames.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return tagNames.stream()
+            .filter(StringUtils::hasText)
+            .map(String::trim)
+            .collect(Collectors.toList());
+  }
+
+  public List<CommunityTag> toTagsForMutation(List<String> tagNames) {
+    List<String> normalizedNames = normalizeTagNames(tagNames);
+    if (normalizedNames.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return normalizedNames.stream()
+            .map(this::getTagByName)
+            .collect(Collectors.toList());
+  }
+
+  public List<CommunityTag> toTagsForSearch(List<String> tagNames) {
+    List<String> normalizedNames = normalizeTagNames(tagNames);
+    if (normalizedNames.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return normalizedNames.stream()
+            .map(name -> CommunityTag.builder().name(name).build())
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/imfine/ngs/community/service/CommunityUserService.java
+++ b/src/main/java/com/imfine/ngs/community/service/CommunityUserService.java
@@ -1,0 +1,40 @@
+package com.imfine.ngs.community.service;
+
+import com.imfine.ngs._global.config.security.jwt.JwtUserPrincipal;
+import com.imfine.ngs.community.dto.CommunityUser;
+import com.imfine.ngs.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+public class CommunityUserService {
+  private final UserRepository userRepository;
+
+  private CommunityUser loadUser(Long userId, HttpStatus status, String message) {
+    return userRepository.findById(userId)
+            .map(CommunityUser::of)
+            .orElseThrow(() -> new ResponseStatusException(status, message));
+  }
+
+  public CommunityUser getAuthorOrThrow(Long authorId) {
+    return loadUser(authorId, HttpStatus.NOT_FOUND, "작성자를 찾을 수 없습니다.");
+  }
+
+  public CommunityUser getCommunityUserOrAnonymous(JwtUserPrincipal principal) {
+    if (principal == null) {
+      return CommunityUser.builder().build();
+    }
+
+    return loadUser(principal.getUserId(), HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
+  }
+
+  public CommunityUser getCommunityUserOrThrow(JwtUserPrincipal principal) {
+    if (principal == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
+    return getCommunityUserOrAnonymous(principal);
+  }
+}

--- a/src/test/java/com/imfine/ngs/community/controller/CommunityPostControllerTest.java
+++ b/src/test/java/com/imfine/ngs/community/controller/CommunityPostControllerTest.java
@@ -18,6 +18,7 @@ import com.imfine.ngs.community.entity.CommunityTag;
 import com.imfine.ngs.community.enums.SearchType;
 import com.imfine.ngs.community.service.CommunityPostService;
 import com.imfine.ngs.community.service.CommunityTagService;
+import com.imfine.ngs.community.service.CommunityUserService;
 import com.imfine.ngs.user.entity.User;
 import com.imfine.ngs.user.entity.UserRole;
 import com.imfine.ngs.user.entity.UserStatus;
@@ -46,6 +47,9 @@ class CommunityPostControllerTest {
   private CommunityTagService communityTagService;
 
   @Mock
+  private CommunityUserService communityUserService;
+
+  @Mock
   private UserRepository userRepository;
 
   @Mock
@@ -70,7 +74,7 @@ class CommunityPostControllerTest {
         .status(UserStatus.builder().name("ACTIVE").description("Active user").build())
         .build();
 
-    when(mapper.getCommunityUserOrThrow(principal)).thenReturn(CommunityUser.of(mockUser));
+    when(communityUserService.getCommunityUserOrThrow(principal)).thenReturn(CommunityUser.of(mockUser));
   }
 
   @Test


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 기존에 유저와 태그를 찾아주던 CommunityMapper의 책임을 담당 서비스에게 인가했습니다.
2. 이로인해 CommunityMapper는 다른 Bean을 사용하지 않게 되어 정적 클래스로 수정했습니다.
3. 또한 기존에 다대다 변환 작업을 stream().map()을 사용하도록 변경하여 Mapper는 오직 엔티티 : dto 일대일 변환만 담당합니다.

<br>

## 📌Issue
> 닫을 issue 번호 : resolved #191 

<br>

## 🩼Branch
> 반영 branch refactor-191 -> dev

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

refactor-191 머지 후 refactor-190 머지하는게 올바르게 된겁니다
혼동을 드려서 죄송함다..