### PR TITLE
[feat] 장바구니/주문 분리 및 주문 생성/취소 API 추가

### DIFF
--- a/src/main/java/com/imfine/ngs/order/controller/OrderController.java
+++ b/src/main/java/com/imfine/ngs/order/controller/OrderController.java
@@ -69,4 +69,32 @@ public class OrderController {
                         .toList()
         );
     }
+
+    @GetMapping("/{orderId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<OrderResponseDto> getOrderDetail(
+            @AuthenticationPrincipal JwtUserPrincipal principal,
+            @PathVariable Long orderId) {
+        Long userId = principal.getUserId();
+        Order order = orderService.getOrderDetail(userId, orderId);
+        return ResponseEntity.ok(mapper.toOrderResponseDto(order));
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<OrderResponseDto> createOrderFromCart(@AuthenticationPrincipal JwtUserPrincipal principal) {
+        Long userId = principal.getUserId();
+        Order order = orderService.createOrderFromCart(userId);
+        return ResponseEntity.ok(mapper.toOrderResponseDto(order));
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<OrderResponseDto> cancelOrder(
+            @AuthenticationPrincipal JwtUserPrincipal principal,
+            @PathVariable Long orderId) {
+        Long userId = principal.getUserId();
+        Order cancelledOrder = orderService.cancelOrder(userId, orderId);
+        return ResponseEntity.ok(mapper.toOrderResponseDto(cancelledOrder));
+    }
 }

--- a/src/main/java/com/imfine/ngs/order/entity/Order.java
+++ b/src/main/java/com/imfine/ngs/order/entity/Order.java
@@ -30,10 +30,18 @@ public class Order extends BaseTimeEntity {
 
     private String merchantUid; // 주문 고유 ID
 
+    // 장바구니용 생성자 (merchantUid 없음)
     public Order(Long userId) {
         this.userId = userId;
         this.status = OrderStatus.PENDING;
-        this.merchantUid = UUID.randomUUID().toString();
+        this.merchantUid = null; // 장바구니는 merchantUid 없음
+    }
+
+    // 주문용 생성자 (merchantUid 생성)
+    public Order(Long userId, boolean isOrder) {
+        this.userId = userId;
+        this.status = OrderStatus.PENDING;
+        this.merchantUid = isOrder ? UUID.randomUUID().toString() : null;
     }
 
     public void addOrderDetail(OrderDetails detail) {

--- a/src/main/java/com/imfine/ngs/order/repository/OrderRepository.java
+++ b/src/main/java/com/imfine/ngs/order/repository/OrderRepository.java
@@ -10,7 +10,12 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByUserId(Long userId);
 
+    List<Order> findByUserIdAndStatusNot(Long userId, OrderStatus status);
+
     Optional<Order> findByUserIdAndStatus(Long userId, OrderStatus status);
+
+    // 장바구니 조회 (merchantUid가 null이고 PENDING 상태)
+    Optional<Order> findByUserIdAndStatusAndMerchantUidIsNull(Long userId, OrderStatus status);
 
     Optional<Order> findByMerchantUid(String merchantUid);
 

--- a/src/main/java/com/imfine/ngs/order/service/OrderService.java
+++ b/src/main/java/com/imfine/ngs/order/service/OrderService.java
@@ -26,7 +26,8 @@ public class OrderService {
 
     // 장바구니(PENDING 상태의 주문) 조회 또는 생성
     public Order getOrCreateCart(Long userId) {
-        return orderRepository.findByUserIdAndStatus(userId, OrderStatus.PENDING)
+        // merchantUid가 null이고 PENDING 상태인 것만 장바구니로 간주
+        return orderRepository.findByUserIdAndStatusAndMerchantUidIsNull(userId, OrderStatus.PENDING)
                 .orElseGet(() -> orderRepository.save(new Order(userId)));
     }
 
@@ -87,6 +88,61 @@ public class OrderService {
 
     @Transactional(readOnly = true)
     public List<Order> getOrdersByUserId(Long userId) {
-        return orderRepository.findByUserId(userId);
+        // PENDING 상태 주문 제외 (장바구니와 결제 전 주문 제외)
+        return orderRepository.findByUserIdAndStatusNot(userId, OrderStatus.PENDING);
+    }
+
+    @Transactional(readOnly = true)
+    public Order getOrderDetail(Long userId, Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 본인의 주문인지 확인
+        if (!order.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        return order;
+    }
+
+    // 장바구니에서 주문 생성 (결제 전)
+    public Order createOrderFromCart(Long userId) {
+        Order cart = getOrCreateCart(userId);
+
+        // 장바구니가 비어있는지 확인
+        if (cart.getOrderDetails().isEmpty()) {
+            throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND);
+        }
+
+        // 새로운 주문 생성 (merchantUid 생성)
+        Order newOrder = new Order(userId, true);
+
+        // 장바구니 아이템들을 새 주문으로 복사
+        for (OrderDetails cartDetail : cart.getOrderDetails()) {
+            OrderDetails orderDetail = new OrderDetails(newOrder, cartDetail.getGame());
+            newOrder.addOrderDetail(orderDetail);
+        }
+
+        // 장바구니 비우기 (순서 중요!)
+        List<OrderDetails> detailsToRemove = List.copyOf(cart.getOrderDetails());
+        cart.getOrderDetails().clear();
+        orderDetailsRepository.deleteAll(detailsToRemove);
+
+        return orderRepository.save(newOrder);
+    }
+
+    // 주문 취소 (PAYMENT_COMPLETED 상태만 가능)
+    public Order cancelOrder(Long userId, Long orderId) {
+        Order order = getOrderDetail(userId, orderId);
+
+        // 결제 완료 상태가 아니면 취소 불가
+        if (order.getStatus() != OrderStatus.PAYMENT_COMPLETED) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // 주문 상태를 환불 요청으로 변경
+        order.setStatus(OrderStatus.REFUND_REQUESTED);
+
+        return orderRepository.save(order);
     }
 }

--- a/src/main/java/com/imfine/ngs/payment/controller/PaymentController.java
+++ b/src/main/java/com/imfine/ngs/payment/controller/PaymentController.java
@@ -20,7 +20,11 @@ public class PaymentController {
     @PostMapping("/complete")
     public ResponseEntity<PaymentCompleteResponse> completePayment(@RequestBody PaymentCompleteRequest request) {
         try {
-            PaymentCompleteResponse response = paymentService.completePayment(request.getPaymentId());
+            PaymentCompleteResponse response = paymentService.completePayment(
+                    request.getPaymentId(),
+                    request.getMerchantUid(),
+                    request.getAmount()
+            );
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             // 서비스 레이어에서 던져진 예외를 클라이언트에게 전달

--- a/src/main/java/com/imfine/ngs/payment/dto/PaymentCompleteRequest.java
+++ b/src/main/java/com/imfine/ngs/payment/dto/PaymentCompleteRequest.java
@@ -1,12 +1,14 @@
 package com.imfine.ngs.payment.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class PaymentCompleteRequest {
-    private String paymentId;
-
-    public PaymentCompleteRequest(String paymentId) {
-        this.paymentId = paymentId;
-    }
+    private String paymentId;      // imp_uid
+    private String merchantUid;    // 주문번호
+    private Long amount;           // 결제 금액
 }

--- a/src/main/java/com/imfine/ngs/payment/service/PaymentService.java
+++ b/src/main/java/com/imfine/ngs/payment/service/PaymentService.java
@@ -28,62 +28,44 @@ public class PaymentService {
     private final OrderHistoryRepository orderHistoryRepository;
 
     @Transactional
-    public PaymentCompleteResponse completePayment(String paymentId) {
-        // 1. PortOne API를 통해 결제 정보 조회
-        PortOnePaymentData portOnePayment;
-        try {
-            portOnePayment = portOneApiClient.getPayment(paymentId);
-            if (portOnePayment == null) {
-                // PortOne에서 데이터를 못받아오는 경우.
-                throw new BusinessException(ErrorCode.PORTONE_API_ERROR);
-            }
-        } catch (Exception e) {
-            logger.error("PortOne API 호출 중 오류 발생 (paymentId: {})", paymentId, e);
-            throw new BusinessException(ErrorCode.PORTONE_API_ERROR);
-        }
-        logger.debug("PortOne 결제 정보 조회 성공: {}", portOnePayment);
+    public PaymentCompleteResponse completePayment(String paymentId, String merchantUid, Long amount) {
+        logger.info("결제 완료 처리 시작 - paymentId: {}, merchantUid: {}, amount: {}", paymentId, merchantUid, amount);
 
-        // 2. 우리 DB에서 주문 정보 조회
-        final Order order = orderRepository.findByMerchantUid(portOnePayment.getMerchantUid())
+        // 1. 우리 DB에서 주문 정보 조회
+        final Order order = orderRepository.findByMerchantUid(merchantUid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         try {
-            // 3. 결제 상태 확인 (PortOne)
-            if (!"PAID".equalsIgnoreCase(portOnePayment.getStatus())) {
-                throw new BusinessException(ErrorCode.PAYMENT_NOT_COMPLETED);
-            }
-
-            // 4. 이미 처리된 주문인지 확인 (우리 DB)
+            // 2. 이미 처리된 주문인지 확인 (우리 DB)
             if (order.isPaid()) {
-                // 예외를 발생시켜 클라이언트에게 일관된 에러 메시지를 전달
                 throw new BusinessException(ErrorCode.PAYMENT_ALREADY_COMPLETED);
             }
 
-            // 5. 결제 금액 검증
-            final long paidAmount = portOnePayment.getAmount().getTotal();
+            // 3. 결제 금액 검증
             final long expectedAmount = order.getTotalPrice();
+            logger.debug("금액 검증 - 결제금액: {}, 주문금액: {}", amount, expectedAmount);
 
-            if (paidAmount != expectedAmount) {
-                // 금액이 일치하지 않으면 PortOne 결제를 취소해야 함
-                portOneApiClient.cancelPayment(paymentId);
+            if (amount == null || amount != expectedAmount) {
+                logger.error("금액 불일치 - 결제금액: {}, 주문금액: {}", amount, expectedAmount);
                 throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
             }
 
-            // 6. 모든 검증 통과 -> 주문 상태를 '결제 완료'로 변경
+            // 4. 모든 검증 통과 -> 주문 상태를 '결제 완료'로 변경
             order.paymentCompleted();
             orderHistoryRepository.save(new OrderHistory(order, order.getStatus()));
 
-            // 7. Payment 객체 생성 및 저장
-            Payment payment = new Payment(order, paidAmount, paymentId);
+            // 5. Payment 객체 생성 및 저장
+            Payment payment = new Payment(order, amount, paymentId);
             paymentRepository.save(payment);
 
+            logger.info("결제 완료 처리 성공 - orderId: {}, paymentId: {}", order.getOrderId(), paymentId);
             return new PaymentCompleteResponse("PAID", "결제가 성공적으로 완료되었습니다.");
 
         } catch (BusinessException e) {
             // 검증 과정에서 비즈니스 예외 발생 시 주문 상태를 '결제 실패'로 변경
+            logger.error("결제 검증 실패 - orderId: {}, error: {}", order.getOrderId(), e.getMessage());
             order.paymentFailed();
             orderHistoryRepository.save(new OrderHistory(order, order.getStatus()));
-            // GlobalExceptionHandler가 처리하도록 예외를 다시 던짐
             throw e;
         }
     }


### PR DESCRIPTION
## ⭐Key Changes
> 장바구니에서 결제하도록 로직을 수정하고 기능하게 합니다.

1.  - 주문 목록 조회 시 장바구니 제외
2.  - POST /api/orders - 장바구니에서 주문 생성
3. - GET /api/orders/{orderId} - 주문 상세 조회
4. - POST /api/orders/{orderId}/cancel - 주문 취소/환불 요청
5. - 결제 검증 로직 개선 (PortOne API 호출 제거)\
6. - 주문 목록 조회 시 장바구니 제외

<br>

## 📌Issue
> 닫을 issue 번호 : resolved #199 

<br>

## 🩼Branch
> 반영 branch feat-199 -> dev

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.